### PR TITLE
feat: enable live attendance checkbox updates and improve UI alignment

### DIFF
--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -47,4 +47,6 @@ public interface Logic {
      * Set the user prefs' GUI settings.
      */
     void setGuiSettings(GuiSettings guiSettings);
+
+    seedu.address.model.Model peekModel();
 }

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -85,4 +85,10 @@ public class LogicManager implements Logic {
     public void setGuiSettings(GuiSettings guiSettings) {
         model.setGuiSettings(guiSettings);
     }
+
+    @Override
+    public seedu.address.model.Model peekModel() {
+        return model;
+    }
+
 }

--- a/src/main/java/seedu/address/logic/commands/AttendanceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AttendanceCommand.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.ui.UiAttendanceAccess;
 
 /**
  * Records attendance for a student on a date.
@@ -91,6 +92,14 @@ public class AttendanceCommand extends Command {
         idx.setCurrentUiDate(date);
 
         String statusWord = present ? "Present" : "Absent";
+
+        model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_PERSONS);
+
+        // Force UI to refresh PersonListPanel
+        UiAttendanceAccess.install((n, d) ->
+                model.getAttendanceIndex().get(n, d).orElse(null), () ->
+                model.getAttendanceIndex().getCurrentUiDate());
+
         return new CommandResult("Success: Attendance recorded: " + name + ", " + date + ", " + statusWord + ".");
     }
 }

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -110,6 +110,11 @@ public class MainWindow extends UiPart<Stage> {
      * Fills up all the placeholders of this window.
      */
     void fillInnerParts() {
+
+        seedu.address.ui.UiAttendanceAccess.install((name, date) ->
+                logic.peekModel().getAttendanceIndex().get(name, date).orElse(null), () ->
+                logic.peekModel().getAttendanceIndex().getCurrentUiDate());
+
         System.out.println(logic.getFilteredPersonList());
         personListPanel = new PersonListPanel(logic.getFilteredPersonList());
         personListPanelPlaceholder.getChildren().add(personListPanel.getRoot());
@@ -169,6 +174,19 @@ public class MainWindow extends UiPart<Stage> {
     }
 
     /**
+     * Forces the {@code PersonListPanel} to refresh its visible cells.
+     * <p>
+     * This ensures UI elements such as attendance checkboxes update immediately
+     * after commands like {@code attendance} are executed.
+     * </p>
+     */
+    public void refreshPersonListPanel() {
+        if (personListPanel != null) {
+            personListPanel.refresh();
+        }
+    }
+
+    /**
      * Executes the command and returns the result.
      *
      * @see seedu.address.logic.Logic#execute(String)
@@ -178,6 +196,7 @@ public class MainWindow extends UiPart<Stage> {
             CommandResult commandResult = logic.execute(commandText);
             logger.info("Result: " + commandResult.getFeedbackToUser());
             resultDisplay.setFeedbackToUser(commandResult.getFeedbackToUser());
+            refreshPersonListPanel();
 
             if (commandResult.isShowHelp()) {
                 handleHelp();

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -1,6 +1,7 @@
 package seedu.address.ui;
 
 import javafx.fxml.FXML;
+import javafx.scene.control.CheckBox;
 import javafx.scene.control.Label;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
@@ -32,6 +33,9 @@ public class PersonCard extends UiPart<Region> {
     private Label phone;
     @FXML
     private Label lessonTime;
+    @FXML
+    private CheckBox attendanceCheck;
+
 
     /**
      * Creates a {@code PersonCode} with the given {@code Person} and index to display.
@@ -43,5 +47,7 @@ public class PersonCard extends UiPart<Region> {
         name.setText(person.getName().fullName);
         phone.setText(person.getPhone().value);
         lessonTime.setText(person.getLessonTime().toString());
+        Boolean status = UiAttendanceAccess.getStatus(person.getName().fullName);
+        attendanceCheck.setSelected(Boolean.TRUE.equals(status));
     }
 }

--- a/src/main/java/seedu/address/ui/PersonListPanel.java
+++ b/src/main/java/seedu/address/ui/PersonListPanel.java
@@ -30,6 +30,14 @@ public class PersonListPanel extends UiPart<Region> {
     }
 
     /**
+     * Forces the list view to refresh its visible cells.
+     * This ensures attendance checkboxes update immediately after any attendance command.
+     */
+    public void refresh() {
+        personListView.refresh();
+    }
+
+    /**
      * Custom {@code ListCell} that displays the graphics of a {@code Person} using a {@code PersonCard}.
      */
     class PersonListViewCell extends ListCell<Person> {
@@ -45,5 +53,4 @@ public class PersonListPanel extends UiPart<Region> {
             }
         }
     }
-
 }

--- a/src/main/java/seedu/address/ui/UiAttendanceAccess.java
+++ b/src/main/java/seedu/address/ui/UiAttendanceAccess.java
@@ -1,0 +1,48 @@
+package seedu.address.ui;
+
+import java.time.LocalDate;
+import java.util.function.BiFunction;
+import java.util.function.Supplier;
+
+/**
+ * Provides a simple bridge for UI components to access attendance information
+ * without requiring direct references to the {@code Model}.
+ * <p>
+ * This class allows the UI (e.g. {@code PersonCard}) to query whether a student's
+ * attendance is present, absent, or unrecorded for the currently displayed date.
+ * The logic layer installs function references through {@link #install(BiFunction, Supplier)},
+ * enabling loose coupling between the UI and model.
+ * </p>
+ */
+public final class UiAttendanceAccess {
+    /** Function that returns the student's attendance status (true = present, false = absent, null = not recorded). */
+    private static BiFunction<String, LocalDate, Boolean> attendanceFn = (n, d) -> null;
+
+    /** Supplier that provides the current date used for attendance lookup. */
+    private static Supplier<LocalDate> currentDateSupplier = LocalDate::now;
+
+    /** Prevents instantiation of this utility class. */
+    private UiAttendanceAccess() {}
+
+    /**
+     * Installs the function and date supplier used by UI elements to query attendance.
+     *
+     * @param fn a function mapping (student name, date) → attendance status
+     * @param dateSupplier a supplier providing the current date to query
+     */
+    public static void install(BiFunction<String, LocalDate, Boolean> fn,
+                               Supplier<LocalDate> dateSupplier) {
+        attendanceFn = fn;
+        currentDateSupplier = dateSupplier;
+    }
+
+    /**
+     * Returns the attendance status for the given student on the current UI date.
+     *
+     * @param name the student's name
+     * @return {@code true} if present, {@code false} if absent, or {@code null} if not recorded
+     */
+    public static Boolean getStatus(String name) {
+        return attendanceFn.apply(name, currentDateSupplier.get());
+    }
+}

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -7,42 +7,37 @@
 <HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/17.0.12" xmlns:fx="http://javafx.com/fxml/1">
     <GridPane HBox.hgrow="ALWAYS">
         <columnConstraints>
-            <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />
+            <ColumnConstraints hgrow="ALWAYS" minWidth="10" prefWidth="400" />
+            <ColumnConstraints hgrow="NEVER" prefWidth="100" halignment="RIGHT" />
         </columnConstraints>
+        <rowConstraints>
+            <RowConstraints />
+        </rowConstraints>
+
+        <!-- Left: Person details -->
         <VBox alignment="CENTER_LEFT" minHeight="105" GridPane.columnIndex="0">
             <padding>
                 <Insets bottom="5" left="15" right="5" top="5" />
             </padding>
             <HBox alignment="CENTER_LEFT" spacing="0.5">
-                <Label fx:id="id" styleClass="cell_big_label">
-                    <minWidth>
-                        <!-- Ensures that the label text is never truncated -->
-                        <Region fx:constant="USE_PREF_SIZE" />
-                    </minWidth>
-                </Label>
-                <Label fx:id="name" styleClass="cell_big_label" text="\$first" />
+                <Label fx:id="id" styleClass="cell_big_label" />
+                <Label fx:id="name" styleClass="cell_big_label" />
             </HBox>
             <HBox alignment="CENTER_LEFT" spacing="0.5">
-                <Label fx:id="phoneId" styleClass="cell_small_label" text="Phone number: ">
-                    <minWidth>
-                        <!-- Ensures that the label text is never truncated -->
-                        <Region fx:constant="USE_PREF_SIZE" />
-                    </minWidth>
-                </Label>
-                <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" HBox.hgrow="ALWAYS" />
+                <Label fx:id="phoneId" styleClass="cell_small_label" text="Phone number:" />
+                <Label fx:id="phone" styleClass="cell_small_label" HBox.hgrow="ALWAYS" />
             </HBox>
             <HBox alignment="CENTER_LEFT" spacing="0.5">
-                <Label fx:id="lessonTimeId" styleClass="cell_small_label" text="Lesson Time: ">
-                    <minWidth>
-                        <!-- Ensures that the label text is never truncated -->
-                        <Region fx:constant="USE_PREF_SIZE" />
-                    </minWidth>
-                </Label>
-                <Label fx:id="lessonTime" styleClass="cell_small_label" text="\$lessonTime" HBox.hgrow="ALWAYS" />
+                <Label fx:id="lessonTimeId" styleClass="cell_small_label" text="Lesson Time:" />
+                <Label fx:id="lessonTime" styleClass="cell_small_label" HBox.hgrow="ALWAYS" />
             </HBox>
         </VBox>
-        <rowConstraints>
-            <RowConstraints />
-        </rowConstraints>
+
+        <CheckBox fx:id="attendanceCheck" disable="true"
+                  GridPane.columnIndex="1" GridPane.halignment="RIGHT">
+            <padding>
+                <Insets right="30" />
+            </padding>
+        </CheckBox>
     </GridPane>
 </HBox>

--- a/src/test/java/seedu/address/logic/commands/AttendanceCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AttendanceCommandTest.java
@@ -20,8 +20,9 @@ import seedu.address.model.UserPrefs;
 import seedu.address.model.attendance.AttendanceIndex;
 import seedu.address.model.person.Person;
 
-
-/** Tests for {@link AttendanceCommand}. */
+/**
+ * Tests for {@link AttendanceCommand}.
+ */
 public class AttendanceCommandTest {
 
     @Test
@@ -46,8 +47,10 @@ public class AttendanceCommandTest {
     public void execute_duplicateSameStatus_throws() throws Exception {
         Model model = new ModelStubWithPerson("Alex Yeoh");
 
+        // first record: success
         new AttendanceCommand("Alex Yeoh", "2025-09-19", "1").execute(model);
 
+        // duplicate with same status
         AttendanceCommand dup = new AttendanceCommand("Alex Yeoh", "2025-09-19", "1");
         CommandException ex = assertThrows(CommandException.class, () -> dup.execute(model));
         assertEquals("Student Alex Yeoh is already marked as Present on 2025-09-19.", ex.getMessage());
@@ -56,8 +59,9 @@ public class AttendanceCommandTest {
     @Test
     public void execute_invalidName_throws() {
         Model model = new ModelStubWithPerson("Alex Yeoh");
-        AttendanceCommand cmd = new AttendanceCommand("", "2025-09-19", "1");
-        assertThrows(CommandException.class, () -> cmd.execute(model));
+        AttendanceCommand cmd = new AttendanceCommand("Nonexistent", "2025-09-19", "1");
+        CommandException ex = assertThrows(CommandException.class, () -> cmd.execute(model));
+        assertEquals("Invalid student name: no matching student found.", ex.getMessage());
     }
 
     @Test
@@ -76,7 +80,9 @@ public class AttendanceCommandTest {
         assertEquals("Invalid status. Use 1 for present, 0 for absent.", ex.getMessage());
     }
 
-    /** Minimal model stub that supports hasPersonName() and attendance index. */
+    /**
+     * Minimal model stub supporting hasPersonName() and AttendanceIndex.
+     */
     private static class ModelStubWithPerson implements Model {
         private final String storedName;
         private final AttendanceIndex index = new AttendanceIndex();
@@ -89,7 +95,7 @@ public class AttendanceCommandTest {
             return s.trim().replaceAll("\\s+", " ").toLowerCase();
         }
 
-        // ------ Methods used by AttendanceCommand ------
+        // --- Methods used by AttendanceCommand ---
 
         @Override
         public boolean hasPersonName(String name) {
@@ -101,7 +107,12 @@ public class AttendanceCommandTest {
             return index;
         }
 
-        // ------ Unused Model methods: keep compilable, but fail if called ------
+        @Override
+        public void updateFilteredPersonList(Predicate<Person> predicate) {
+            // no-op
+        }
+
+        // --- Unused methods (throw AssertionError if called) ---
 
         @Override
         public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
@@ -166,11 +177,6 @@ public class AttendanceCommandTest {
         @Override
         public ObservableList<Person> getFilteredPersonList() {
             return FXCollections.observableArrayList();
-        }
-
-        @Override
-        public void updateFilteredPersonList(Predicate<Person> predicate) {
-            throw new AssertionError();
         }
     }
 }


### PR DESCRIPTION
- Added UiAttendanceAccess#getStatus() to distinguish present/absent/unrecorded states.
- Updated PersonCard to tick/untick checkbox based on attendance status.
- Adjusted FXML layout so attendance checkbox aligns neatly on the right with padding.
- Added PersonListPanel#refresh() and MainWindow#refreshPersonListPanel() to force immediate UI refresh after attendance changes.
- Triggered list refresh after executing attendance command to update checkboxes instantly without scrolling.
- Added missing Javadoc comments for new methods to satisfy Checkstyle.

fixes #45 